### PR TITLE
Add build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Temporary Items
 
 # End of https://www.toptal.com/developers/gitignore/api/macos
 
+# Temporary files for building the wordnet
+etc/
+kurdnet-*
+build.log

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+VERSION="1.0"
+DTD="WN-LMF-1.1.dtd"
+
+# 
+mkdir -p etc
+if [ ! -d etc/cili ]; then
+    echo "Retrieving ILI map"
+    git clone https://github.com/globalwordnet/cili.git etc/cili
+fi
+
+if [ ! -d etc/omw-data ]; then
+    echo "Retrieving omw-data"
+    git clone https://github.com/omwn/omw-data.git etc/omw-data
+fi
+
+if [ ! -f etc/"${DTD}" ]; then
+    echo "Retrieving DTD"
+    wget "https://globalwordnet.github.io/schemas/${DTD}" -O etc/"$DTD"
+fi
+
+citation=$( sed -r -e '/^$/d' -e 's/\s+$//' ckb/citation.rst )
+
+NAME="kurdnet-${VERSION}"
+DIR="$NAME"
+
+echo "Preparing package directory"
+mkdir -p "$DIR"
+cp README.md "$DIR"
+cp LICENSE "$DIR"
+cp ckb/citation.bib "$DIR"
+
+echo "Building wordnet"
+DESTINATION="${DIR}/${NAME}.xml"
+PYTHONPATH=etc/omw-data python3 -m scripts.tsv2lmf \
+	  ckb/wn-data-ckb.tab \
+	  "$DESTINATION" \
+	  --id='kurdnet' \
+	  --label='KurdNet (Kurdish WordNet)' \
+	  --language='ckb' \
+	  --version="$VERSION" \
+	  --email='ahmadi.sina@outlook.com' \
+	  --license='https://creativecommons.org/licenses/by-sa/4.0/' \
+	  --url="https://github.com/sinaahmadi/kurdnet" \
+	  --citation="${citation}" \
+	  --requires=omw-en:1.4 \
+	  --ili-map=etc/cili/ili-map-pwn30.tab \
+	  --log=build.log
+
+# ensure the xml is valid
+echo "Validating"
+xmlstarlet val -d etc/"$DTD" "$DESTINATION"
+
+# archive the package
+echo "Archiving the package"
+tar --checkpoint=.10 -c -J -f "${NAME}.tar.xz" "$DIR"


### PR DESCRIPTION
I made the `tsv2lmf` script in [omw-data](https://github.com/omwn/omw-data/) more easily runnable for non-OMW data, so in this PR I added a `build.sh` script to fetch the requirements and build the wordnet as discussed in #2. It does the following:

1. Fetches CILI, omw-data, and the WN-LMF-1.1 schema to help with building the wordnet, if they aren't already present
2. Prepares a `kurdnet-1.0` directory to contain the wordnet and extra files `README.md`, `LICENSE`, and `citation.bib`.
3. Builds the `kurdnet-1.0.xml` wordnet file
4. Validates that the XML file follows the schema
5. Archives and compresses the built directory

You will want to install some dependencies for Python before running the script:

```console
$ python -m pip install wn tomli
```

Then it's just a matter of running the script:

```console
$ ./build.sh
```

When it's done, you can attach the `kurdnet-1.0.tar.xz` file to a release you've created on GitHub. If you want to automate things, you can call the script from a GitHub Actions workflow and use the `gh` command (specifically [gh release upload](https://cli.github.com/manual/gh_release_upload)) to attach the file to the release.

Some things to note:
- To change the version (e.g., `1.0`), edit the `VERSION` variable at the top of `build.sh`
- I copy the `README.md` in the top directory instead of the one under `ckb/` because it looks more like something you'd want distributed with the wordnet; change the `cp README.md` line if this is not the case
- I used your email address from your public GitHub profile as the maintainer email in the lexicon instead of Francis's email
- Running `build.sh` creates a log file `build.log` with some notes about errors or omissions in the data. You may find these useful.
- The `etc/` and `kurdnet-1.0/` directories, and the `kurdnet-1.0.tar.xz` files
